### PR TITLE
Added Texture parameter to PIXI.loaders.Resource.

### DIFF
--- a/pixi.d.ts
+++ b/pixi.d.ts
@@ -1536,6 +1536,7 @@ declare module PIXI {
             constructor(name?: string, url?: string | string[], options?: LoaderOptions);
 
             name: string;
+            texture: Texture;
             url: string;
             data: any;
             crossOrigin: string;


### PR DESCRIPTION
This line adds texture parameter to Resource object so it has to be included in declaration to: https://github.com/GoodBoyDigital/pixi.js/blob/master/src/loaders/textureParser.js#L10
