### PR TITLE
Fix definition file for TypeScript 1.6

### DIFF
--- a/pixi.d.ts
+++ b/pixi.d.ts
@@ -507,7 +507,7 @@ declare module PIXI {
         preserveDrawingBuffer?: boolean;
         forceFXAA?: boolean;
         roundPixels?: boolean;
-
+        backgroundColor: number;
     }
     export class SystemRenderer extends EventEmitter {
 


### PR DESCRIPTION
TypeScript 1.6 will be making a breaking change where object literals with excess properties will cause an error. As part of a sweep through DefinitelyTyped (https://github.com/Microsoft/TypeScript/issues/4081), I found that pixi's tests were causing errors, though the only errors I see in the tests are 

```
Error TS2345 Argument of type '{ backgroundColor: number; }' is not assignable to parameter of type 'RendererOptions'.
  Object literal may only specify known properties, and 'backgroundColor' does not exist in type 'RendererOptions'.
```

I added a `backgroundColor` property to `RendererOptions` to fix this, but if there are any others that are missing, we should add them to avoid breaks in consumer code.
