### PR TITLE
Fixed definition RENDER_TYPE to RENDERER_TYPE (PIXI.RENDERER_TYPE)

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -10,7 +10,7 @@ declare class PIXI {
     static RAD_TO_DEG: number;
     static DEG_TO_RAD: number;
     static TARGET_FPMS: number;
-    static RENDER_TYPE: {
+    static RENDERER_TYPE: {
         UNKNOWN: number;
         WEBGL: number;
         CANVAS: number;


### PR DESCRIPTION
PIXI has a RENDERER_TYPE constant, not RENDER_TYPE
