### PR TITLE
Fix the type of PIXI.loader.Loader.resources.

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -1532,6 +1532,10 @@ declare module PIXI {
             xhrType?: string;
 
         }
+        export interface ResourceDictionary {
+
+            [index: string]: PIXI.loaders.Resource;
+        }
         export class Loader extends EventEmitter {
 
             constructor(baseUrl?: string, concurrency?: number);
@@ -1539,7 +1543,7 @@ declare module PIXI {
             baseUrl: string;
             progress: number;
             loading: boolean;
-            resources: Resource[];
+            resources: ResourceDictionary;
 
             add(name: string, url: string, options?: LoaderOptions, cb?: () => void): Loader;
             add(url: string, options?: LoaderOptions, cb?: () => void): Loader;


### PR DESCRIPTION
PIXI.loader.Loader.resources is actually a dictionary/map instead of a number indexed array in typescript. Array can be string indexed in raw javascript, but not in typescript.
