### PR TITLE
Shader class typos.

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -771,8 +771,8 @@ declare module PIXI {
         fragmentSrc: string;
 
         init(): void;
-        cachUniformLocations(keys: string): void;
-        cacheAttributeLocations(keys: string): void;
+        cacheUniformLocations(keys: string[]): void;
+        cacheAttributeLocations(keys: string[]): void;
         compile(): WebGLProgram;
         syncUniform(uniform: any): void;
         syncUniforms(): void;


### PR DESCRIPTION
#### Corrected:
- cachUniformLocations -> cacheUniformLocations,
- the parameter of cacheUniformLocations and cacheAttributeLocations set to a string[].
