### PR TITLE
correct EventEmitter3 method parameters for off, removeEventListener

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -87,10 +87,10 @@ declare module PIXI {
         emit(event: string, ...args: any[]): boolean;
         on(event: string, fn: Function, context?: any): EventEmitter;
         once(event: string, fn: Function, context?: any): EventEmitter;
-        removeListener(event: string, fn: Function, once?: boolean): EventEmitter;
+        removeListener(event: string, fn: Function, context?: any, once?: boolean): EventEmitter;
         removeAllListeners(event: string): EventEmitter;
 
-        off(event: string, fn: Function, once?: boolean): EventEmitter;
+        off(event: string, fn: Function, context?: any, once?: boolean): EventEmitter;
         addListener(event: string, fn: Function, context?: any): EventEmitter;
 
     }


### PR DESCRIPTION
This corrects the re-exported interface for EventEmitter3 to match the EventEmitter class's `off` and `removeEventListener` method types.  (Note that these are in fact the same function.)

See https://github.com/primus/eventemitter3/blob/1f3065f57149fdb70a3fe315ad0b6e8a3d8a4282/index.js#L178
