### PR TITLE
Moved PIXI.filters.FXAAFilter to PIXI.FXAAFilter, to match the documentation

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -667,6 +667,11 @@ declare module PIXI {
         offset: Point;
 
     }
+    export class FXAAFilter extends AbstractFilter {
+
+        applyFilter(renderer: WebGLRenderer, input: RenderTarget, output: RenderTarget): void;
+
+    }
     export class BlendModeManager extends WebGLManager {
 
         constructor(renderer: WebGLRenderer);
@@ -1425,11 +1430,6 @@ declare module PIXI {
             offset: Point;
             radius: number;
             angle: number;
-
-        }
-        export class FXAAFilter extends AbstractFilter {
-
-            applyFilter(renderer: WebGLRenderer, input: RenderTarget, output: RenderTarget): void;
 
         }
     }


### PR DESCRIPTION
and the actual PIXI object. 

See pixijs/pixi.js#2312

The documentation: https://pixijs.github.io/docs/PIXI.FXAAFilter.html states that it is available on PIXI.FXAAFilter, but this declaration file stated that is was on PIXI.filters.FXAAFilter. 

This fixes that. 
