### PR TITLE
Added declarations for some renderers

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -302,7 +302,7 @@ declare module PIXI {
         drawShape(shape: Circle | Rectangle | Ellipse | Polygon): GraphicsData;
 
     }
-    export interface GraphicsRenderer extends ObjectRenderer {
+    export class GraphicsRenderer extends ObjectRenderer {
         //yikes todo
     }
     export interface WebGLGraphicsData {
@@ -490,8 +490,18 @@ declare module PIXI {
         destroy(): void;
 
     }
-    export interface ParticleRenderer {
+    export class ParticleRenderer extends ObjectRenderer {
+        new (renderer: PIXI.WebGLRenderer);
 
+        buildCircle: (graphicsData: PIXI.Graphics, webGLData: WebGLGraphicsData) => void;
+        buildPoly: (graphicsData: PIXI.Graphics, webGLData: WebGLGraphicsData) => boolean;
+        buildRectangle: (graphicsData: PIXI.Graphics, webGLData: WebGLGraphicsData) => void;
+        buildComplexPoly: (graphicsData: PIXI.Graphics, webGLData: WebGLGraphicsData) => void;
+        buildLine: (graphicsData: PIXI.Graphics, webGLData: WebGLGraphicsData) => void;
+        updateGraphics: (graphics: PIXI.Graphics) => void;
+        buildRoundedRectangle: (graphicsData: PIXI.Graphics, webGLData: WebGLGraphicsData) => void;
+        quadraticBezierCurve: (fromX: number, fromY: number, cpX: number, cpY: number, toX: number, toY: number, out: number[]) => number[];
+        switchMode: (webGL: WebGLRenderingContext, type: number) => WebGLGraphicsData;
     }
     export interface ParticleShader {
 

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -303,7 +303,17 @@ declare module PIXI {
 
     }
     export class GraphicsRenderer extends ObjectRenderer {
-        //yikes todo
+        new (renderer: PIXI.WebGLRenderer) : GraphicsRenderer
+
+        buildCircle: (graphicsData: PIXI.Graphics, webGLData: Object) => void;
+        buildPoly: (graphicsData: PIXI.Graphics, webGLData: Object) => boolean;
+        buildRectangle: (graphicsData: PIXI.Graphics, webGLData: Object) => void;
+        buildComplexPoly: (graphicsData: PIXI.Graphics, webGLData: Object) => any;
+        buildLine: (graphicsData: PIXI.Graphics, webGLData: Object) => any;
+        updateGraphics: (graphics: PIXI.Graphics) => void;
+        buildRoundedRectangle: (graphicsData: PIXI.Graphics, webGLData: Object) => void;
+        quadraticBezierCurve: (fromX: number, fromY: number, cpX: number, cpY: number, toX: number, toY: number, out: any) => Array<any>;
+        switchMode: (webGL: WebGLRenderingContext, type: number) => WebGLGraphicsData;
     }
     export interface WebGLGraphicsData {
         //yikes todo!

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -303,20 +303,24 @@ declare module PIXI {
 
     }
     export class GraphicsRenderer extends ObjectRenderer {
-        new (renderer: PIXI.WebGLRenderer) : GraphicsRenderer
+        new (renderer: PIXI.WebGLRenderer);
 
         buildCircle: (graphicsData: PIXI.Graphics, webGLData: Object) => void;
         buildPoly: (graphicsData: PIXI.Graphics, webGLData: Object) => boolean;
         buildRectangle: (graphicsData: PIXI.Graphics, webGLData: Object) => void;
-        buildComplexPoly: (graphicsData: PIXI.Graphics, webGLData: Object) => any;
-        buildLine: (graphicsData: PIXI.Graphics, webGLData: Object) => any;
+        buildComplexPoly: (graphicsData: PIXI.Graphics, webGLData: Object) => void;
+        buildLine: (graphicsData: PIXI.Graphics, webGLData: Object) => void;
         updateGraphics: (graphics: PIXI.Graphics) => void;
         buildRoundedRectangle: (graphicsData: PIXI.Graphics, webGLData: Object) => void;
-        quadraticBezierCurve: (fromX: number, fromY: number, cpX: number, cpY: number, toX: number, toY: number, out: any) => Array<any>;
+        quadraticBezierCurve: (fromX: number, fromY: number, cpX: number, cpY: number, toX: number, toY: number, out: any) => number[];
         switchMode: (webGL: WebGLRenderingContext, type: number) => WebGLGraphicsData;
     }
-    export interface WebGLGraphicsData {
-        //yikes todo!
+    export class WebGLGraphicsData {
+        new (gl: WebGLRenderingContext);
+
+        upload: () => void;
+        reset: () => void;
+        destroy: () => void;
     }
 
     //math


### PR DESCRIPTION
Added some type declarations for GraphicsRenderer, WebGLGraphicsData and ParticleRenderer. 

They are based on an automatically generated declaration file, but I looked at bit at the Pixi.js source, to make them reasonable. 

Also see: pixijs/pixi.js#2312 
