### PR TITLE
Made PIXI from a class to a module

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -3,19 +3,19 @@
 // Definitions by: clark-stevenson <https://github.com/pixijs/pixi-typescript>
 // Definitions: https://github.com/borisyankov/DefinitelyTyped
 
-declare class PIXI {
+declare module PIXI {
 
-    static VERSION: string;
-    static PI_2: number;
-    static RAD_TO_DEG: number;
-    static DEG_TO_RAD: number;
-    static TARGET_FPMS: number;
-    static RENDERER_TYPE: {
+    export var VERSION: string;
+    export var PI_2: number;
+    export var RAD_TO_DEG: number;
+    export var DEG_TO_RAD: number;
+    export var TARGET_FPMS: number;
+    export var RENDERER_TYPE: {
         UNKNOWN: number;
         WEBGL: number;
         CANVAS: number;
     };
-    static BLEND_MODES: {
+    export var BLEND_MODES: {
         NORMAL: number;
         ADD: number;
         MULTIPLY: number;
@@ -35,7 +35,7 @@ declare class PIXI {
         LUMINOSITY: number;
 
     };
-    static DRAW_MODES: {
+    export var DRAW_MODES: {
         POINTS: number;
         LINES: number;
         LINE_LOOP: number;
@@ -44,15 +44,15 @@ declare class PIXI {
         TRIANGLE_STRIP: number;
         TRIANGLE_FAN: number;
     };
-    static SCALE_MODES: {
+    export var SCALE_MODES: {
         DEFAULT: number;
         LINEAR: number;
         NEAREST: number;
     };
-    static RETINA_PREFIX: string;
-    static RESOLUTION: number;
-    static FILTER_RESOLUTION: number;
-    static DEFAULT_RENDER_OPTIONS: {
+    export var RETINA_PREFIX: string;
+    export var RESOLUTION: number;
+    export var FILTER_RESOLUTION: number;
+    export var DEFAULT_RENDER_OPTIONS: {
         view: HTMLCanvasElement;
         resolution: number;
         antialias: boolean;
@@ -64,18 +64,14 @@ declare class PIXI {
         preserveDrawingBuffer: boolean;
         roundPixels: boolean;
     };
-    static SHAPES: {
+    export var SHAPES: {
         POLY: number;
         RECT: number;
         CIRC: number;
         ELIP: number;
         RREC: number;
     };
-    static SPRITE_BATCH_SIZE: number;
-
-}
-
-declare module PIXI {
+    export var SPRITE_BATCH_SIZE: number;
 
     export function autoDetectRenderer(width: number, height: number, options?: PIXI.RendererOptions, noWebGL?: boolean): PIXI.WebGLRenderer | PIXI.CanvasRenderer;
     export var loader: PIXI.loaders.Loader;


### PR DESCRIPTION
In the declaration file, it states that PIXI is a class (and a module). 

This means that calling `new PIXI()` should be OK, since it is a class, even though it doesn't have any fields, or explicit constructors, because it still have an implicit constructor. 

This pull-request changes it from a class and a module, to just a module, with the static fields changed into exported variables. 
The only change for a user should be that `new PIXI()` is no longer valid TypeScript. 
