### PR TITLE
RETINA_PREFIX is actually a RegExp.

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -49,7 +49,7 @@ declare module PIXI {
         LINEAR: number;
         NEAREST: number;
     };
-    export var RETINA_PREFIX: string;
+    export var RETINA_PREFIX: RegExp;
     export var RESOLUTION: number;
     export var FILTER_RESOLUTION: number;
     export var DEFAULT_RENDER_OPTIONS: {


### PR DESCRIPTION
The declaration file states that RETINA_PREFIX is a string. 

But it is actually the constant /@(.+)x/, which is of type RegExp.
