### PR TITLE
RoundedRectangle: EMPTY and clone

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -468,10 +468,8 @@ declare module PIXI {
         height: number;
         radius: number;
         type: number;
-
-        static EMPTY: Rectangle;
-
-        clone(): Rectangle;
+        
+        clone(): RoundedRectangle;
         contains(x: number, y: number): boolean;
 
     }


### PR DESCRIPTION
Reactangle does have an field EMPTY, but RoundedRectangle doesn't. 

And clone is changed to return the more correct RoundedRectangle, instead of just Reactangle.
