### PR TITLE
Texture doesn't actually extend BaseTexture

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -1099,7 +1099,7 @@ declare module PIXI {
         getCanvas(): HTMLCanvasElement;
 
     }
-    export class Texture extends BaseTexture {
+    export class Texture extends EventEmitter {
 
         static fromImage(imageUrl: string, crossOrigin?: boolean, scaleMode?: number): Texture;
         static fromFrame(frameId: string): Texture;


### PR DESCRIPTION
It just takes it as an argument in the constructor. 

The relevant line of source code: "Texture.prototype = Object.create(EventEmitter.prototype);"
