### PR TITLE
getChildByName belongs on Container, and not displayObject

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -172,7 +172,6 @@ declare module PIXI {
         setParent(container: Container): Container;
         setTransform(x?: number, y?: number, scaleX?: number, scaleY?: number, rotation?: number, skewX?: number, skewY?: number, pivotX?: number, pivotY?: number): DisplayObject;
         destroy(): void;
-        getChildByName(name: string): DisplayObject;
         getGlobalPosition(point: Point): Point;
 
         interactive: boolean;
@@ -240,6 +239,7 @@ declare module PIXI {
         getChildIndex(child: DisplayObject): number;
         setChildIndex(child: DisplayObject, index: number): void;
         getChildAt(index: number): DisplayObject;
+        getChildByName(name: string): DisplayObject;
         removeChild(child: DisplayObject): DisplayObject;
         removeChildAt(index: number): DisplayObject;
         removeChildren(beginIndex?: number, endIndex?: number): DisplayObject[];


### PR DESCRIPTION
From the source code: 

```
/**
* Returns the display object in the container
*
* @memberof PIXI.Container#
* @param name {string} instance name
* @return {PIXI.DisplayObject}
*/
core.Container.prototype.getChildByName = function (name)
```

I'm quite sure I could continue this all day, but I think I'm done for now. 
