### PR TITLE
Additional types for Text style.fill to match supported CanvasRenderingContext2D.fillStyle (https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/fillStyle) since PIXI.js assigns style.fill directly to context.fillStyle.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,7 @@ npm-debug.log
 *__temp
 node_modules
 *-tests.js
+
+# Jetbrains IntelliJ
+.idea
+*.iml

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -991,7 +991,7 @@ declare module PIXI {
     export interface TextStyle {
 
         font?: string;
-        fill?: string | number;
+        fill?: string | number | CanvasGradient | CanvasPattern;
         align?: string;
         stroke?: string | number;
         strokeThickness?: number;


### PR DESCRIPTION
I recently updated the PIXI.js doc to reflect the additional support of fill styles: https://github.com/pixijs/pixi.js/pull/2543

This is a change to support the Gradient options for fillStyle.

I also added some ignores for IntelliJ files.
