### PR TITLE
CanvasTinter is a plain object, not a class.

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -664,17 +664,17 @@ declare module PIXI {
         destroy(): void;
 
     }
-    export class CanvasTinter {
+    export module CanvasTinter {
 
-        static getTintedTexture(sprite: DisplayObject, color: number): HTMLCanvasElement;
-        static tintWithMultiply(texture: Texture, color: number, canvas: HTMLDivElement): void;
-        static tintWithOverlay(texture: Texture, color: number, canvas: HTMLCanvasElement): void;
-        static tintWithPerPixel(texture: Texture, color: number, canvas: HTMLCanvasElement): void;
-        static roundColor(color: number): number;
-        static cacheStepsPerColorChannel: number;
-        static convertTintToImage: boolean;
-        static vanUseMultiply: boolean;
-        static tintMethod: Function;
+        export function getTintedTexture(sprite: DisplayObject, color: number): HTMLCanvasElement;
+        export function tintWithMultiply(texture: Texture, color: number, canvas: HTMLDivElement): void;
+        export function tintWithOverlay(texture: Texture, color: number, canvas: HTMLCanvasElement): void;
+        export function tintWithPerPixel(texture: Texture, color: number, canvas: HTMLCanvasElement): void;
+        export function roundColor(color: number): number;
+        export var cacheStepsPerColorChannel: number;
+        export var convertTintToImage: boolean;
+        export var vanUseMultiply: boolean;
+        export var tintMethod: Function;
 
     }
     export class WebGLRenderer extends SystemRenderer {


### PR DESCRIPTION
It's always a little suspicious when a class only contains static fields. 

Relevant code: 

``` JavaScript
/**
 * Utility methods for Sprite/Texture tinting.
 * @static
 * @class
 * @memberof PIXI
 */
var CanvasTinter = {};
```

Hmm. The JSDoc is also wrong, and [the documentation](https://pixijs.github.io/docs/PIXI.CanvasTinter.html). 

All stating that `new PIXI.CanvasTinter()` is valid. 

I can create a pull-request for the JSDoc over in the main repo if you want.
