### PR TITLE
support for texture atlas textures by name

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -1686,6 +1686,11 @@ declare module PIXI {
             load(cb?: (loader: loaders.Loader, object: any) => void): Loader;
 
         }
+
+        export interface TextureDictionary {
+            [index: string]: PIXI.Texture;
+        }
+
         export class Resource extends utils.EventEmitter {
 
             static LOAD_TYPE: {
@@ -1716,7 +1721,7 @@ declare module PIXI {
 
             name: string;
             texture: Texture;
-            textures: Texture[];
+            textures: TextureDictionary;
             url: string;
             data: any;
             crossOrigin: boolean | string;


### PR DESCRIPTION
allows `PIXI.loader.resources['myAtlas'].textures["mytexture.png"]`
