### PR TITLE
Forgot to update type of setter in previous commit

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -1080,7 +1080,7 @@ declare module PIXI {
 
         stencilMaskStack: Graphics[];
 
-        setMaskStack(stencilMasStack: StencilMaskStack[]): void;
+        setMaskStack(stencilMasStack: Graphics[]): void;
         pushStencil(graphics: Graphics): void;
         popStencil(): void;
         destroy(): void;


### PR DESCRIPTION
In this commit: https://github.com/pixijs/pixi-typescript/pull/63/commits/01974a6da19fae8dafadaa4a9d09068fe114f710  

I updated the field, but not the setter that sets the field. 

In this pull-request, the setter is updated. 

This is the JSDoc for the setter. 

``` JavaScript
/**
  * Changes the mask stack that is used by this manager.
  *
  * @param stencilMaskStack {PIXI.Graphics[]} The mask stack
  */
```
