### PR TITLE
public calculateVerticies

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -1148,12 +1148,12 @@ declare module PIXI {
         protected cachedTint: number;
         texture: Texture;
         protected textureDirty: boolean;
-        protected vertexData: number[];
+        vertexData: number[];
         width: number;
         height: number;
 
         protected _onTextureUpdate(): void;
-        protected calculateVertices(): void;
+        calculateVertices(): void;
         protected _calculateBounds(): void;
         protected calculateBoundsVertices(): void;
         protected onAnchorUpdate(): void;


### PR DESCRIPTION
Can't see any reason to make this protected considering it's public in the code and this functionality is helpful to determine a sprite's rotated rectangle.
