### PR TITLE
Corrected PIXI.SCALE_MODES

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -124,10 +124,9 @@ declare module PIXI {
             TRIANGLE_FAN: number;
         };
         export var SCALE_MODES: {
-            DEFAULT: number;
-            CLAMP: number;
-            REPEAT: number;
-            MIRRORED_REPEAT: number;
+            DEFAULT: number,
+            LINEAR: number,
+            NEAREST: number
         };
         export var GC_MODES: {
             DEFAULT: number;


### PR DESCRIPTION
It seems like the scale modes was a bit copypasted from the wrapmodes :)
