### PR TITLE
PIXI.MovieClip frame members should be read only and small parameter naming for goto methods.

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -1611,12 +1611,12 @@ declare module PIXI {
             onComplete: () => void;
             protected _currentTime: number;
             playing: boolean;
-            totalFrames: number;
-            currentFrame: number;
+            readonly totalFrames: number;
+            readonly currentFrame: number;
             stop(): void;
             play(): void;
-            gotoAndStop(frameName: number): void;
-            gotoAndPlay(frameName: number): void;
+            gotoAndStop(frameNumber: number): void;
+            gotoAndPlay(frameNumber: number): void;
             protected update(deltaTime: number): void;
             destroy(): void;
 


### PR DESCRIPTION
Another small request that caused issues for me when moving to newer PIXI. 

I was thinking twice about this yesterday, as the readonly is new to typescript 2 and it was RC. Today it was officially released and i think it would be nice to use this flag. 

Any thoughts about this? this did give me an error runtime, which i think should be avoided to any extent possible. 

If you agree, i might start looking through the documentation for readonly parameters and fix them accordingly :) 
