### PR TITLE
Correct typing for filter uniforms

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -1131,15 +1131,25 @@ declare module PIXI {
         destroy(): void;
 
     }
+    export interface IUniformData {
 
+        type: string;
+        value: any;
+
+        // name is set by pixi if uniforms were automatically extracted from shader code, but not used anywhere
+        name?: string;
+
+    }
     export class Filter {
 
-        constructor(vertexSrc?: string, fragmentSrc?: string, uniforms?: string);
+        // param uniforms should be an object matching type {[name: string]: IUniformData};
+        // left untyped as there's no way to define the type without requiring an index signature or making this class generic
+        constructor(vertexSrc?: string, fragmentSrc?: string, uniforms?: any);
 
         vertextSrc: string;
         fragmentSrc: string;
-        protected uniformData: WebGLUniformLocation;
-        uniforms: any;
+        protected uniformData: {[name: string]: IUniformData};
+        uniforms: {[name: string]: any};
         glShaders: any;
         glShaderKey: string;
         padding: number;

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -1134,7 +1134,7 @@ declare module PIXI {
 
     export class Filter {
 
-        constructor(vertexSrc: string, fragmentSrc: string, uniforms: string);
+        constructor(vertexSrc?: string, fragmentSrc?: string, uniforms?: string);
 
         vertextSrc: string;
         fragmentSrc: string;


### PR DESCRIPTION
Typings for Filter.uniformData and 'uniforms' param in Filter constructor were wrong.

Filter class could be made generic to preserve typing for uniforms, but as generics aren't used elsewhere in the typings, I left them partially untyped for consistency's sake.


(Does this merge properly with #108 ? I thought splitting them up would be good for clarity but who knows.)