### PR TITLE
addChild to return the type of the added child.

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -228,9 +228,9 @@ declare module PIXI {
         height: number;
 
         protected onChildrenChange: (...args: any[]) => void;
-        addChild(child: DisplayObject): DisplayObject;
+        addChild<T extends DisplayObject>(child: T, ): T;
         addChild(...child: DisplayObject[]): DisplayObject;
-        addChildAt(child: DisplayObject, index: number): DisplayObject;
+        addChildAt<T extends DisplayObject>(child: T, index: number): T;
         swapChildren(child: DisplayObject, child2: DisplayObject): void;
         getChildIndex(child: DisplayObject): number;
         setChildIndex(child: DisplayObject, index: number): void;

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -228,8 +228,7 @@ declare module PIXI {
         height: number;
 
         protected onChildrenChange: (...args: any[]) => void;
-        addChild<T extends DisplayObject>(child: T, ): T;
-        addChild(...child: DisplayObject[]): DisplayObject;
+        addChild<T extends DisplayObject>(child: T, ...additionalChildren: DisplayObject[]): T;
         addChildAt<T extends DisplayObject>(child: T, index: number): T;
         swapChildren(child: DisplayObject, child2: DisplayObject): void;
         getChildIndex(child: DisplayObject): number;


### PR DESCRIPTION
Add child always returns the child that was just added, updated the definitions to reflect that.