### PR TITLE
Fix argument type in Text._generateFillStyle

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -1375,7 +1375,7 @@ declare module PIXI {
         protected wordWrap(text: string): string;
         protected _calculateBounds(): void;
         protected _onStyleChange: () => void;
-        protected _generateFillStyle(style: string | number | CanvasGradient, lines: string[]): string | number | CanvasGradient;
+        protected _generateFillStyle(style: TextStyle, lines: string[]): string | number | CanvasGradient;
         destroy(options?: IDestroyOptions | boolean): void;
         dirty: boolean;
 


### PR DESCRIPTION
The correct argument type for this method should be, as near as I can tell, `TextStyle`.  This method doesn't seem to be listed in the docs, but can be found [here](http://pixijs.download/release/docs/core_text_Text.js.html) on line 505.