### PR TITLE
Adding Resource.texture removed after update to ResourceLoader v2.0.3.

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -2253,7 +2253,6 @@ declare namespace PIXI {
             url: string;
             extension: string;
             data: any;
-            texture: Texture;
             crossOrigin: boolean | string;
             loadType: number;
             xhrType: string;

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -2214,12 +2214,6 @@ declare namespace PIXI {
             protected _onComplete(): void;
             protected _onLoad(resource: Resource): void;
 
-            // these are added for spine support
-
-            spineAtlas: any;
-            spineData: any;
-            textures?: ITextureDictionary;
-
             // depreciation
 
             on(event: "complete", fn: (loader: loaders.Loader, object: any) => void, context?: any): utils.EventEmitter;

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -2339,6 +2339,10 @@ declare namespace PIXI {
 
             static EMPTY_GIF: string;
 
+            texture: Texture;
+            spineAtlas: any;
+            spineData: any;
+            textures?: ITextureDictionary;
         }
     }
 

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -2253,6 +2253,7 @@ declare namespace PIXI {
             url: string;
             extension: string;
             data: any;
+            texture: Texture;
             crossOrigin: boolean | string;
             loadType: number;
             xhrType: string;


### PR DESCRIPTION
Adding Resource.texture removed after update to ResourceLoader v2.0.3. This property is added by Pixi, it's not a part of the 3rd-party library.