### PR TITLE
Correct point types for DisplayObject members

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -374,10 +374,10 @@ declare namespace PIXI {
         y: number;
         worldTransform: Matrix;
         localTransform: Matrix;
-        position: Point;
-        scale: Point;
-        pivot: Point;
-        skew: Point;
+        position: Point | ObservablePoint;
+        scale: Point | ObservablePoint;
+        pivot: Point | ObservablePoint;
+        skew: ObservablePoint;
         rotation: number;
         worldVisible: boolean;
         mask: PIXI.Graphics | PIXI.Sprite;

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -674,7 +674,7 @@ declare namespace PIXI {
         y: number;
 
         clone(): Point;
-        copy(p: Point): void;
+        copy(p: Point | ObservablePoint): void;
         equals(p: Point): boolean;
         set(x?: number, y?: number): void;
 


### PR DESCRIPTION
Position, scale & pivot vary in type depending on `settings.TRANSFORM_MODE`. `ObservablePoint` lacks `clone` and `equals` methods of `Point` class which makes them not quite interchangeable.