### PR TITLE
Add textureGC to WebGLRenderer

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -939,6 +939,7 @@ declare namespace PIXI {
         boundTextures: Texture[];
         filterManager: FilterManager;
         textureManager?: TextureManager;
+        textureGC?: TextureGarbageCollector;
         extract: extract.WebGLExtract;
         protected drawModes: any;
         protected _activeShader: Shader;


### PR DESCRIPTION
Adds WebGLRenderer's instance of TextureGarbageCollector as a property. Apparently the property lacks documentation, but is useful to access if one wants to change its settings on the fly.