### PR TITLE
Expose activate method of Accessibility Manager

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -76,6 +76,9 @@ declare namespace PIXI {
 
             constructor(renderer: CanvasRenderer | WebGLRenderer);
 
+            public activate(): void;
+            public deactivate(): void;
+
             protected div: HTMLElement;
             protected pool: HTMLElement[];
             protected renderId: number;
@@ -84,8 +87,6 @@ declare namespace PIXI {
             protected children: AccessibleTarget[];
             protected isActive: boolean;
 
-            protected activate(): void;
-            protected deactivate(): void;
             protected updateAccessibleObjects(displayObject: DisplayObject): void;
             protected update(): void;
             protected capHitArea(hitArea: HitArea): void;


### PR DESCRIPTION
Expose activate and deactivate methods to allow keyboard only applications to enable accessibility without using Tab key.