### PR TITLE
added PointLike, updated DisplayObject functions

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -394,13 +394,13 @@ declare namespace PIXI {
         getBounds(skipUpdate?: boolean, rect?: Rectangle): Rectangle;
         getLocalBounds(rect?: Rectangle): Rectangle;
         //creates and returns a new point
-        toGlobal(position: Point | ObservablePoint): Point;
+        toGlobal(position:PointLike): Point;
         //modifies the x and y of the passed point and returns it
-        toGlobal<T extends Point | ObservablePoint>(position: Point | ObservablePoint, point?: T, skipUpdate?: boolean): T;
+        toGlobal<T extends PointLike>(position: PointLike, point?: T, skipUpdate?: boolean): T;
         //creates and returns a new point
         toLocal(position: PointLike, from?: DisplayObject): Point;
         //modifies the x and y of the passed point and returns it
-        toLocal<T extends Point | ObservablePoint>(position: Point | ObservablePoint, from?: DisplayObject, point?: T, skipUpdate?: boolean): T;
+        toLocal<T extends PointLike>(position: PointLike, from?: DisplayObject, point?: T, skipUpdate?: boolean): T;
         renderWebGL(renderer: WebGLRenderer): void;
         renderCanvas(renderer: CanvasRenderer): void;
         setParent(container: Container): Container;

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -393,8 +393,14 @@ declare namespace PIXI {
         protected _recursivePostUpdateTransform(): void;
         getBounds(skipUpdate?: boolean, rect?: Rectangle): Rectangle;
         getLocalBounds(rect?: Rectangle): Rectangle;
-        toGlobal(position: Point, point?: Point, skipUpdate?: boolean): Point;
-        toLocal(position: Point, from?: DisplayObject, point?: Point, skipUpdate?: boolean): Point;
+        //creates and returns a new point
+        toGlobal(position: Point | ObservablePoint): Point;
+        //modifies the x and y of the passed point and returns it
+        toGlobal<T extends Point | ObservablePoint>(position: Point | ObservablePoint, point?: T, skipUpdate?: boolean): T;
+        //creates and returns a new point
+        toLocal(position: PointLike, from?: DisplayObject): Point;
+        //modifies the x and y of the passed point and returns it
+        toLocal<T extends Point | ObservablePoint>(position: Point | ObservablePoint, from?: DisplayObject, point?: T, skipUpdate?: boolean): T;
         renderWebGL(renderer: WebGLRenderer): void;
         renderCanvas(renderer: CanvasRenderer): void;
         setParent(container: Container): Container;
@@ -659,32 +665,32 @@ declare namespace PIXI {
         static TEMP_MATRIX: Matrix;
 
     }
-    export class ObservablePoint {
+
+    class PointLike {
+
+        x: number;
+        y: number;
+
+        set(x?: number, y?: number): void;
+        copy(point: PointLike): void;        
+
+    }
+
+    export class ObservablePoint extends PointLike {
 
         constructor(cb: () => any, scope?: any, x?: number, y?: number);
 
-        x: number;
-        y: number;
         cb: () => any;
         scope: any;
 
-        set(x?: number, y?: number): void;
-        copy(point: Point | ObservablePoint): void;
-
     }
-    export class Point {
+
+    export class Point extends PointLike {
 
         constructor(x?: number, y?: number);
 
-        x: number;
-        y: number;
-
-        // See https://github.com/pixijs/pixi-typescript/issues/156
         clone(): Point;
-
-        copy(p: Point | ObservablePoint): void;
-        equals(p: Point): boolean;
-        set(x?: number, y?: number): void;
+        equals(p: PointLike): boolean;
 
     }
 


### PR DESCRIPTION
This restores the ability to call DisplayObject::toGlobal and DisplayObject::toLocal with either `Point` or `ObservablePoint` objects.

Currently, when calling toGlobal or toLocal as follows (the last line):

```
let c = new PIXI.Container();
let s = new PIXI.Sprite();
c.addChild(s);
let p = new PIXI.Point(0,0);

let res = c.toGlobal(s.position)
```
You'll get an error that type Point | ObservablePoint is not assignable to parameter of type 'Point'.

In this PR, I've done two things:

1.  I've added a `PointLike` type which serves as a sort of "base class" for both Point and ObservablePoint, and cleaned up the definitions of the respective classes.

2.  I've added overridden methods for `DisplayObject::toLocal` and `DisplayObject::toGlobal` which reflect the fact that when passing a second Point object, it's x and y properties are changed, and the passed object is returned (when omitting the second Point object, a new Point will be created and returned).

I've used generics so that when passing the second Point object, the return type will be inferred from the type that was passed, and we can avoid casting:

```
//mock function which returns either a Point or an ObservablePoint
var func = ():PIXI.Point|PIXI.ObservablePoint=>{return null!};

let c = new PIXI.Container();
let p = new PIXI.Point(0,0);
let p2 = new PIXI.Point(0,0);
let op = new PIXI.ObservablePoint(()=>{},null,0,0);
var either = func(); //either = PIXI.Point | PIXI.ObservablePoint

//create a new point
let res = c.toGlobal(p); //res = PIXI.Point

//modify an existing point
let res2 = c.toGlobal(p,p2); //res2 = PIXI.Point

//create a new point from an ObservablePoint
let res3 = c.toGlobal(op); //res3 = PIXI.Point

//modify an existing ObservablePoint
let res4 = c.toGlobal(p,op); //res4 = PIXI.ObservablePoint

//create a new point from a Point|ObservablePoint
let res5 = c.toGlobal(either); //res5 = PIXI.Point

//modify an existing Point|ObservablePoint
let res6 = c.toGlobal(p,either); //res6 = PIXI.Point|Pixi.ObservablePoint
```

I've only used toGlobal in the examples, since toLocal works in the same way.

Let me know what you think!