### PR TITLE
2nd parameter of VertexArrayObject's constructor can be optional

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -2872,7 +2872,7 @@ declare namespace PIXI {
             drawType: number;
             data: ArrayBuffer | ArrayBufferView | any;
 
-            upload(data: ArrayBuffer | ArrayBufferView | any, offset?: number, dontBind?: boolean): void;
+            upload(data?: ArrayBuffer | ArrayBufferView | any, offset?: number, dontBind?: boolean): void;
             bind(): void;
 
             static createVertexBuffer(gl: WebGLRenderingContext, data: ArrayBuffer | ArrayBufferView | any, drawType: number): GLBuffer;

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -2981,7 +2981,7 @@ declare namespace PIXI {
 
             static FORCE_NATIVE: boolean;
 
-            constructor(gl: WebGLRenderingContext, state: WebGLState);
+            constructor(gl: WebGLRenderingContext, state?: WebGLState);
 
             protected nativeVaoExtension: any;
             protected nativeState: AttribState;


### PR DESCRIPTION
According to the implementation of the [class MeshRenderer](https://github.com/pixijs/pixi.js/blob/ba291b08fdcd733e735490dab540171e218d2469/src/mesh/webgl/MeshRenderer.js#L79), the second parameter `state` in the VertexArrayBuffer's constructor is optional.

```js
// build the vao object that will render..
glData.vao = new glCore.VertexArrayObject(gl)
.addIndex(glData.indexBuffer)
```