### PR TITLE
Remove unused WebGLRenderer.interaction & CanvasRenderer.interaction properties

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -902,9 +902,6 @@ declare namespace PIXI {
         destroyPlugins(): void;
         // plugintarget mixin end
 
-        // from InteractionManager
-        interaction?: interaction.InteractionManager;
-
         constructor(options?: RendererOptions);
         constructor(screenWidth?: number, screenHeight?: number, options?: RendererOptions);
 

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -971,9 +971,6 @@ declare namespace PIXI {
         destroyPlugins(): void;
         // plugintarget mixin end
 
-        // from InteractionManager
-        interaction: interaction.InteractionManager;
-
         constructor(options?: WebGLRendererOptions);
         constructor(screenWidth?: number, screenHeight?: number, options?: WebGLRendererOptions);
 


### PR DESCRIPTION
Couldn't find any reference to this in pixi itself. Pretty sure it's supposed to be `WebGLRenderer.plugins.interaction`.

Edit: CanvasRenderer had this as well, whoops.