### PR TITLE
Add typing for renderer plugins

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -901,7 +901,6 @@ declare namespace PIXI {
     interface DefaultCanvasRendererPlugins {
         extract: extract.CanvasExtract;
         prepare: prepare.CanvasPrepare;
-
     }
     export interface CanvasRendererPlugins extends DefaultCanvasRendererPlugins, RendererPlugins {
     }
@@ -972,7 +971,6 @@ declare namespace PIXI {
     interface DefaultWebGLRendererPlugins {
         extract: extract.WebGLExtract;
         prepare: prepare.WebGLPrepare;
-
     }
     export interface WebGLRendererPlugins extends DefaultWebGLRendererPlugins, RendererPlugins {
     }

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -860,10 +860,12 @@ declare namespace PIXI {
 
     }
 
-    export interface DefaultRendererPlugins {
+
+    interface DefaultRendererPlugins {
         accessibility: accessibility.AccessibilityManager;
         interaction: interaction.InteractionManager;
-
+    }
+    export interface RendererPlugins extends DefaultRendererPlugins {
     }
     export class SystemRenderer extends utils.EventEmitter {
 
@@ -896,17 +898,19 @@ declare namespace PIXI {
         destroy(removeView?: boolean): void;
 
     }
-    export interface DefaultCanvasRendererPlugins extends DefaultRendererPlugins {
+    interface DefaultCanvasRendererPlugins {
         extract: extract.CanvasExtract;
         prepare: prepare.CanvasPrepare;
 
     }
-    export class CanvasRenderer<Plugins extends object = DefaultCanvasRendererPlugins> extends SystemRenderer {
+    export interface CanvasRendererPlugins extends DefaultCanvasRendererPlugins, RendererPlugins {
+    }
+    export class CanvasRenderer extends SystemRenderer {
 
         // plugintarget mixin start
-        static __plugins: { [pluginName: string]: { new (renderer: CanvasRenderer<any>): any; } };
-        static registerPlugin(pluginName: string, ctor: { new (renderer: CanvasRenderer<any>): any; }): void;
-        plugins: Plugins;
+        static __plugins: { [pluginName: string]: { new (renderer: CanvasRenderer): any; } };
+        static registerPlugin(pluginName: string, ctor: { new (renderer: CanvasRenderer): any; }): void;
+        plugins: CanvasRendererPlugins;
         initPlugins(): void;
         destroyPlugins(): void;
         // plugintarget mixin end
@@ -965,17 +969,19 @@ declare namespace PIXI {
 
     export interface WebGLRendererOptions extends RendererOptions {
     }
-    export interface DefaultWebGLRendererPlugins extends DefaultRendererPlugins {
+    interface DefaultWebGLRendererPlugins {
         extract: extract.WebGLExtract;
         prepare: prepare.WebGLPrepare;
 
     }
-    export class WebGLRenderer<Plugins extends object = DefaultWebGLRendererPlugins> extends SystemRenderer {
+    export interface WebGLRendererPlugins extends DefaultWebGLRendererPlugins, RendererPlugins {
+    }
+    export class WebGLRenderer extends SystemRenderer {
 
         // plugintarget mixin start
-        static __plugins: { [pluginName: string]: { new (renderer: WebGLRenderer<any>): any; } };
-        static registerPlugin(pluginName: string, ctor: { new (renderer: WebGLRenderer<any>): any; }): void;
-        plugins: Plugins;
+        static __plugins: { [pluginName: string]: { new (renderer: WebGLRenderer): any; } };
+        static registerPlugin(pluginName: string, ctor: { new (renderer: WebGLRenderer): any; }): void;
+        plugins: WebGLRendererPlugins;
         initPlugins(): void;
         destroyPlugins(): void;
         // plugintarget mixin end

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -860,6 +860,11 @@ declare namespace PIXI {
 
     }
 
+    export interface DefaultRendererPlugins {
+        accessibility: accessibility.AccessibilityManager;
+        interaction: interaction.InteractionManager;
+
+    }
     export class SystemRenderer extends utils.EventEmitter {
 
         constructor(system: string, options?: RendererOptions);
@@ -891,13 +896,17 @@ declare namespace PIXI {
         destroy(removeView?: boolean): void;
 
     }
-    export class CanvasRenderer extends SystemRenderer {
+    export interface DefaultCanvasRendererPlugins extends DefaultRendererPlugins {
+        extract: extract.CanvasExtract;
+        prepare: prepare.CanvasPrepare;
+
+    }
+    export class CanvasRenderer<Plugins extends object = DefaultCanvasRendererPlugins> extends SystemRenderer {
 
         // plugintarget mixin start
-        static __plugins: any;
-        //tslint:disable-next-line:ban-types forbidden-types
-        static registerPlugin(pluginName: string, ctor: Function): void;
-        plugins: any;
+        static __plugins: { [pluginName: string]: { new (renderer: CanvasRenderer<any>): any; } };
+        static registerPlugin(pluginName: string, ctor: { new (renderer: CanvasRenderer<any>): any; }): void;
+        plugins: Plugins;
         initPlugins(): void;
         destroyPlugins(): void;
         // plugintarget mixin end
@@ -956,14 +965,17 @@ declare namespace PIXI {
 
     export interface WebGLRendererOptions extends RendererOptions {
     }
+    export interface DefaultWebGLRendererPlugins extends DefaultRendererPlugins {
+        extract: extract.WebGLExtract;
+        prepare: prepare.WebGLPrepare;
 
-    export class WebGLRenderer extends SystemRenderer {
+    }
+    export class WebGLRenderer<Plugins extends object = DefaultWebGLRendererPlugins> extends SystemRenderer {
 
         // plugintarget mixin start
-        static __plugins: any;
-        //tslint:disable-next-line:ban-types forbidden-types
-        static registerPlugin(pluginName: string, ctor: Function): void;
-        plugins: any;
+        static __plugins: { [pluginName: string]: { new (renderer: WebGLRenderer<any>): any; } };
+        static registerPlugin(pluginName: string, ctor: { new (renderer: WebGLRenderer<any>): any; }): void;
+        plugins: Plugins;
         initPlugins(): void;
         destroyPlugins(): void;
         // plugintarget mixin end


### PR DESCRIPTION
Allow user to specify type of plugins available for a renderer.

Defaults to [the plugins listed in the docs.](http://pixijs.download/release/docs/PIXI.WebGLRenderer.html#plugins) Users who excluded plugins in a custom build or will register their own plugins should define a custom type instead.

Usage:
```
type CustomPlugins = {
  accessibility: PIXI.accessibility.AccessibilityManager;
  extract: PIXI.extract.CanvasExtract;
};

const customRenderer = new PIXI.WebGLRenderer<CustomPlugins>();
customRenderer.plugins.interaction.mouseMove = e => {}; // error


const defaultRenderer = new PIXI.WebGLRenderer();
defaultRenderer.plugins.interaction.onPointerMove = e => {}; // no problemo
defaultRenderer.plugins.picture; // error: no such property
```