### PR TITLE
setTargetElement should not be protected

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -2315,7 +2315,7 @@ declare namespace PIXI {
             protected _tempPoint: Point;
             resolution: number;
             hitTest(globalPoint: Point, root?: Container): DisplayObject;
-            protected setTargetElement(element: HTMLCanvasElement, resolution?: number): void;
+            setTargetElement(element: HTMLCanvasElement, resolution?: number): void;
             protected addEvents(): void;
             protected removeEvents(): void;
             update(deltaTime?: number): void;


### PR DESCRIPTION
I think the @private flag in pixi is incorrect.. will notify them too.. I've been using this function in my project for 2 years :P