### PR TITLE
Fix incorrect or missing missing type declarations related to spritesheet

### DIFF
--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -1780,7 +1780,7 @@ declare namespace PIXI {
         constructor(baseTexture: BaseTexture, data: any, resolutionFilename?: string);
 
         baseTexture: BaseTexture;
-        animations: { [key: string]: Array<PIXI.Texture>};
+        animations: { [key: string]: Texture[]};
         textures: { [key: string]: Texture };
         data: any;
         resolution: number;
@@ -2593,7 +2593,7 @@ declare namespace PIXI {
             spineAtlas: any;
             spineData: any;
             textures?: TextureDictionary;
-            spritesheet?: PIXI.Spritesheet;
+            spritesheet?: Spritesheet;
         }
         const shared: Loader;
     }

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -1780,7 +1780,7 @@ declare namespace PIXI {
         constructor(baseTexture: BaseTexture, data: any, resolutionFilename?: string);
 
         baseTexture: BaseTexture;
-        animations: { [key: string]: Texture };
+        animations: { [key: string]: Array<PIXI.Texture>};
         textures: { [key: string]: Texture };
         data: any;
         resolution: number;

--- a/pixi.js.d.ts
+++ b/pixi.js.d.ts
@@ -2593,6 +2593,7 @@ declare namespace PIXI {
             spineAtlas: any;
             spineData: any;
             textures?: TextureDictionary;
+            spritesheet?: PIXI.Spritesheet;
         }
         const shared: Loader;
     }


### PR DESCRIPTION
Contains fixes for 2 errors:

- **ERROR: Property spritesheet does not exist on type Resource**
- **ERROR: Argument type Texture is not assignable to parameter type PIXI.Texture[]**

The code that triggers this error:
```
const theme: PIXI.loaders.Resource|undefined = PIXI.loader.resources["images/Theme_01.json"];
const sheet: PIXI.Spritesheet|undefined = theme.spritesheet;
const mySprite: AnimatedSprite = new AnimatedSprite(sheet.animations["sprite_01"]);
```

As a workaround until this is merged, augment pixi.js in the app or game project's `global.d.ts` file:

```
// global.d.ts
import * as PIXI from "pixi.js";

//augment pixi.js
declare module "pixi.js" {
    namespace loaders {
        export interface Resource {
            // FIXME: report bug to PIXI maintainers
            // ERROR: Property spritesheet does not exist on type Resource
            spritesheet?: PIXI.Spritesheet;
        }
    }
}
```

For the second error adding an augmentation in global.d.ts didn't work. My hacky workaround was to just overwrite the declaration in my local copy.  